### PR TITLE
content: añade certificados CS50x (Harvard) y Máster IA (Founderz)

### DIFF
--- a/apps/portfolio/messages/en.json
+++ b/apps/portfolio/messages/en.json
@@ -169,6 +169,18 @@
       ],
       "certifications": [
         {
+          "name": "Máster Online en IA e Innovación 2025",
+          "issuer": "Founderz",
+          "year": "2026",
+          "description": "Master's program in Artificial Intelligence and Innovation applied to business."
+        },
+        {
+          "name": "CS50x: Introduction to Computer Science",
+          "issuer": "Harvard University",
+          "year": "2025",
+          "description": "Computer science and programming fundamentals: C, Python, SQL, algorithms and data structures."
+        },
+        {
           "name": "Zend Certificate of E-Learning – PHP OOP & Software Patterns",
           "issuer": "Zend",
           "year": "2025",

--- a/apps/portfolio/messages/es.json
+++ b/apps/portfolio/messages/es.json
@@ -169,6 +169,18 @@
       ],
       "certifications": [
         {
+          "name": "Máster Online en IA e Innovación 2025",
+          "issuer": "Founderz",
+          "year": "2026",
+          "description": "Máster en Inteligencia Artificial e Innovación aplicada al negocio."
+        },
+        {
+          "name": "CS50x: Introduction to Computer Science",
+          "issuer": "Harvard University",
+          "year": "2025",
+          "description": "Fundamentos de informática y programación: C, Python, SQL, algoritmos y estructuras de datos."
+        },
+        {
           "name": "Zend Certificate of E-Learning – PHP OOP & Software Patterns",
           "issuer": "Zend",
           "year": "2025",


### PR DESCRIPTION
Hotfix: añade dos certificados a la sección de certificaciones (`about.career.certifications`, ES/EN).

## Nuevos certificados
- **CS50x: Introduction to Computer Science** — Harvard University (2025)
- **Máster Online en IA e Innovación 2025** — Founderz (2026)

Orden: más recientes primero (Founderz → CS50x → Zend).

## Verificación
- `next build`: EXIT 0, 16/16 páginas estáticas.
- JSON válido y paridad ES↔EN (3 certificados en cada idioma).

## Nota
- No se añadieron enlaces de verificación ("Ver credencial") para no inventar URLs; los IDs de credencial están disponibles si se quieren cablear los enlaces.
- CV (`cvSesame.md`, `cv_backend_php_laravel_oriented_draft.md`) también actualizados localmente (no versionados en este repo); requieren re-exportar PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)