### PR TITLE
content: reposiciona copy a Full-Stack Developer + IA (hero, about, SEO) y alinea VITA LIBER

### DIFF
--- a/apps/portfolio/messages/en.json
+++ b/apps/portfolio/messages/en.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "title": "{name} | {tagline}",
-    "description": "Tech Lead with experience collaborating with users and clients, accustomed to handling incidents and real needs with clear communication and a solution-oriented attitude. Specialized in translating business requirements into technical solutions.",
+    "description": "Full-stack developer (Symfony/PHP, React/Next.js) with 6+ years building production SaaS: multi-tenant architectures, REST APIs and applied-AI solutions (RAG, OpenAI).",
     "ogImageAlt": "{name} - Professional Portfolio",
     "keywords": [
       "Angel Hidalgo Barreiro",
@@ -63,7 +63,7 @@
   "about": {
     "eyebrow": "Experience",
     "title": "About me",
-    "intro": "Tech Lead with experience collaborating with users and clients, accustomed to handling incidents and real needs with clear communication and a solution-oriented attitude. Focused on translating business requirements into practical solutions with constant follow-up and iterative delivery.",
+    "intro": "Full-stack developer with 6+ years building and shipping production SaaS. Backend with Symfony/PHP and API Platform, frontend with React/Next.js and TypeScript, and applied AI (RAG, OpenAI). Focused on scalable architecture, clean code and quality: from API design to delivery and real-user support.",
     "sections": {
       "timeline": "Professional timeline",
       "activity": "Recent activity",
@@ -118,14 +118,17 @@
           ]
         },
         {
-          "role": "Program Specialist",
+          "role": "Program Specialist (Backend)",
           "company": "Vita Liber S.L.U.",
           "period": {
             "start": "2020",
             "end": "2025"
           },
-          "headline": "Managing internal user needs: prioritization, incidents, validation and functional support.",
-          "achievements": []
+          "headline": "Modernized a legacy system into a backend architecture with PHP/Symfony; developed and maintained REST APIs and core services.",
+          "achievements": [
+            "MariaDB management: schema evolution, migrations and query optimization.",
+            "Automated testing and CI/CD integration."
+          ]
         },
         {
           "role": "Co-founder & Lead Developer",
@@ -752,7 +755,7 @@
     }
   },
   "footer": {
-    "tagline": "I build things",
+    "tagline": "I build products that ship",
     "findMe": "Find me",
     "socialLabel": "Follow me on {network}",
     "copyright": "All rights reserved"
@@ -772,7 +775,7 @@
       "city": "Barcelona",
       "country": "Spain"
     },
-    "tagline": "Tech Lead | Technical Communication | SaaS | Node.js | React | PHP/Symfony",
+    "tagline": "Full-Stack Developer | Symfony · PHP | React/Next.js | Multi-tenant SaaS | Applied AI",
     "bio": {
       "short": "Tech Lead with experience collaborating with users and clients, clear communication and a solution-oriented attitude.",
       "full": "Tech Lead specialized in translating business requirements into technical solutions. Experience leading teams, coordinating with stakeholders, and managing incidents with effective communication. Focused on delivering value through clear communication, task follow-up and iterative delivery."

--- a/apps/portfolio/messages/es.json
+++ b/apps/portfolio/messages/es.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "title": "{name} | {tagline}",
-    "description": "Tech Lead con experiencia colaborando con usuarios y clientes, acostumbrado a tratar incidencias y necesidades reales con comunicación clara y actitud resolutiva. Especializado en traducir requisitos de negocio a soluciones técnicas.",
+    "description": "Desarrollador full-stack (Symfony/PHP, React/Next.js) con 6+ años construyendo SaaS en producción: arquitecturas multi-tenant, APIs REST y soluciones de IA aplicada (RAG, OpenAI).",
     "ogImageAlt": "{name} - Portfolio Profesional",
     "keywords": [
       "Ángel Hidalgo Barreiro",
@@ -63,7 +63,7 @@
   "about": {
     "eyebrow": "Experiencia",
     "title": "Sobre mí",
-    "intro": "Tech Lead con experiencia colaborando con usuarios y clientes, acostumbrado a tratar incidencias y necesidades reales con comunicación clara y actitud resolutiva. Enfocado en traducir requisitos de negocio a soluciones prácticas, con seguimiento constante y entregas iterativas.",
+    "intro": "Desarrollador full-stack con 6+ años construyendo y desplegando SaaS en producción. Backend con Symfony/PHP y API Platform, frontend con React/Next.js y TypeScript, e IA aplicada (RAG, OpenAI). Me centro en arquitectura escalable, clean code y calidad: del diseño de la API a la entrega y el soporte a usuarios reales.",
     "sections": {
       "timeline": "Timeline profesional",
       "activity": "Actividad reciente",
@@ -118,14 +118,17 @@
           ]
         },
         {
-          "role": "Especialista de Programa",
+          "role": "Especialista de Programa (Backend)",
           "company": "Vita Liber S.L.U.",
           "period": {
             "start": "2020",
             "end": "2025"
           },
-          "headline": "Gestión de necesidades de usuarios internos: priorización, incidencias, validación y soporte funcional.",
-          "achievements": []
+          "headline": "Modernización de un sistema legacy a una arquitectura backend con PHP/Symfony; desarrollo y mantenimiento de APIs REST y servicios core.",
+          "achievements": [
+            "Gestión de MariaDB: evolución de esquema, migraciones y optimización de consultas.",
+            "Testing automatizado e integración en procesos CI/CD."
+          ]
         },
         {
           "role": "Cofundador & Lead Developer",
@@ -752,7 +755,7 @@
     }
   },
   "footer": {
-    "tagline": "Desarrollo cosas",
+    "tagline": "Construyo productos que llegan a producción",
     "findMe": "Encuéntrame",
     "socialLabel": "Sígueme en {network}",
     "copyright": "Todos los derechos reservados"
@@ -772,7 +775,7 @@
       "city": "Barcelona",
       "country": "España"
     },
-    "tagline": "Tech Lead | Comunicación técnica | SaaS | Node.js | React | PHP/Symfony",
+    "tagline": "Full-Stack Developer | Symfony · PHP | React/Next.js | SaaS multi-tenant | IA aplicada",
     "bio": {
       "short": "Tech Lead con experiencia colaborando con usuarios y clientes, comunicación clara y actitud resolutiva.",
       "full": "Tech Lead especializado en traducir requisitos de negocio a soluciones técnicas. Experiencia liderando equipos, coordinando con stakeholders, y gestionando incidencias con comunicación efectiva. Enfocado en entregar valor a través de comunicación clara, seguimiento de tareas y entregas iterativas."

--- a/apps/portfolio/src/shared/constants/personal.ts
+++ b/apps/portfolio/src/shared/constants/personal.ts
@@ -44,12 +44,12 @@ export const personalInfo: PersonalInfo = {
     countryCode: 'ES',
   },
 
-  tagline: 'Tech Lead | Comunicación técnica | SaaS | Node.js | React | PHP/Symfony',
+  tagline: 'Full-Stack Developer | Symfony · React/Next.js | SaaS & IA aplicada',
 
   bio: {
     short:
-      'Tech Lead con experiencia colaborando con usuarios y clientes, comunicación clara y actitud resolutiva.',
-    full: 'Tech Lead especializado en traducir requisitos de negocio a soluciones técnicas. Experiencia liderando equipos, coordinando con stakeholders, y gestionando incidencias con comunicación efectiva. Enfocado en entregar valor a través de comunicación clara, seguimiento de tareas y entregas iterativas.',
+      'Desarrollador full-stack (Symfony/PHP, React/Next.js) especializado en SaaS en producción e IA aplicada.',
+    full: 'Desarrollador full-stack con 6+ años construyendo y desplegando SaaS en producción. Backend con Symfony/PHP y API Platform, frontend con React/Next.js y TypeScript. Experiencia en arquitecturas multi-tenant, integraciones de pago (Stripe), cumplimiento fiscal (Veri*factu/AEAT) e IA aplicada (RAG, OpenAI). Enfoque en escalabilidad, clean code y calidad.',
   },
 
   avatar: '/images/avatar-placeholder.svg',
@@ -91,22 +91,22 @@ export const workPreferences = {
  * Professional Focus Areas
  */
 export const focusAreas = [
+  'Full-Stack Development',
+  'SaaS Architecture',
+  'REST API Design',
+  'Multi-tenant Systems',
+  'Applied AI (RAG, OpenAI)',
+  'CI/CD & DevOps',
   'Technical Leadership',
-  'Stakeholder Communication',
-  'Requirements Analysis',
-  'Team Coordination',
-  'Incident Resolution',
-  'Iterative Delivery',
-  'User Support & Training',
-  'Technical Strategy',
+  'Code Quality & Testing',
 ] as const;
 
 /**
  * Years of Experience
  */
 export const experience = {
-  totalYears: 5,
-  startYear: 2020,
+  totalYears: 6,
+  startYear: 2019,
 } as const;
 
 /**
@@ -125,7 +125,7 @@ export const mainTechStack = {
  */
 export const quickStats = {
   projectsCompleted: 35,
-  yearsExperience: 5,
+  yearsExperience: 6,
   technologiesUsed: 20,
   contributionsLastYear: 1706,
   repositoriesContributed: 9,


### PR DESCRIPTION
Refuerza el posicionamiento público del portfolio: pasa de un copy centrado en "Tech Lead / comunicación / incidencias" a **Full-Stack Developer (Symfony + React/Next.js) + IA aplicada**, coherente con el CV y con el trabajo real (SaaS multi-tenant, microservicio Veri*factu, migración ERP).

## Cambios de copy (ES/EN)
- **Hero tagline** (`personal.tagline`): → "Full-Stack Developer | Symfony · PHP | React/Next.js | SaaS multi-tenant | IA aplicada".
- **SEO** (`metadata.description`) y **About intro**: reescritos a perfil de ingeniería full-stack con 6+ años, SaaS en producción, APIs REST e IA aplicada.
- **Footer tagline**: "Desarrollo cosas" → "Construyo productos que llegan a producción" / "I build products that ship".
- **`personal.ts`**: `tagline` (SEO title), `bio.short/full`, `focusAreas` (de soft-skills a ingeniería), `experience.totalYears` 5→6, `quickStats.yearsExperience` 5→6.

## Alineación de honestidad
- **VITA LIBER** en la timeline (`about.career.experiences`, ES/EN): de "gestión de usuarios/soporte" a **dev backend (PHP/Symfony, APIs REST, MariaDB, CI/CD)** — para que coincida con el CV (decisión confirmada del candidato).

## Verificación
- `next build`: EXIT 0, 16/16 páginas estáticas. `tsc --noEmit`: limpio. JSON válido y paridad ES↔EN.

## Nota / a decidir
- Discrepancia de fechas de VITA LIBER: portfolio usa 2020–2025, el CV usa 2021–2025. No se tocó el periodo; conviene unificar el año de inicio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)