### PR TITLE
fix: bio/focusAreas renderizados + tests al nuevo copy

### DIFF
--- a/apps/portfolio/messages/en.json
+++ b/apps/portfolio/messages/en.json
@@ -777,21 +777,21 @@
     },
     "tagline": "Full-Stack Developer | Symfony · PHP | React/Next.js | Multi-tenant SaaS | Applied AI",
     "bio": {
-      "short": "Tech Lead with experience collaborating with users and clients, clear communication and a solution-oriented attitude.",
-      "full": "Tech Lead specialized in translating business requirements into technical solutions. Experience leading teams, coordinating with stakeholders, and managing incidents with effective communication. Focused on delivering value through clear communication, task follow-up and iterative delivery."
+      "short": "Full-stack developer (Symfony/PHP, React/Next.js) specialized in production SaaS and applied AI.",
+      "full": "Full-stack developer with 6+ years building and shipping production SaaS. Backend with Symfony/PHP and API Platform, frontend with React/Next.js and TypeScript. Experience in multi-tenant architectures, payment integrations (Stripe), tax compliance (Veri*factu/AEAT) and applied AI (RAG, OpenAI). Focused on scalable architecture, clean code and quality."
     },
     "availability": {
       "open": "Open to new opportunities"
     },
     "focusAreas": [
+      "Full-Stack Development",
+      "SaaS Architecture",
+      "REST API Design",
+      "Multi-tenant Systems",
+      "Applied AI (RAG, OpenAI)",
+      "CI/CD & DevOps",
       "Technical Leadership",
-      "Stakeholder Communication",
-      "Requirements Analysis",
-      "Team Coordination",
-      "Incident Resolution",
-      "Iterative Delivery",
-      "User Support & Training",
-      "Technical Strategy"
+      "Code Quality & Testing"
     ]
   },
   "career": {}

--- a/apps/portfolio/messages/es.json
+++ b/apps/portfolio/messages/es.json
@@ -777,21 +777,21 @@
     },
     "tagline": "Full-Stack Developer | Symfony · PHP | React/Next.js | SaaS multi-tenant | IA aplicada",
     "bio": {
-      "short": "Tech Lead con experiencia colaborando con usuarios y clientes, comunicación clara y actitud resolutiva.",
-      "full": "Tech Lead especializado en traducir requisitos de negocio a soluciones técnicas. Experiencia liderando equipos, coordinando con stakeholders, y gestionando incidencias con comunicación efectiva. Enfocado en entregar valor a través de comunicación clara, seguimiento de tareas y entregas iterativas."
+      "short": "Desarrollador full-stack (Symfony/PHP, React/Next.js) especializado en SaaS en producción e IA aplicada.",
+      "full": "Desarrollador full-stack con 6+ años construyendo y desplegando SaaS en producción. Backend con Symfony/PHP y API Platform, frontend con React/Next.js y TypeScript. Experiencia en arquitecturas multi-tenant, integraciones de pago (Stripe), cumplimiento fiscal (Veri*factu/AEAT) e IA aplicada (RAG, OpenAI). Enfoque en escalabilidad, clean code y calidad."
     },
     "availability": {
       "open": "Abierto a nuevas oportunidades"
     },
     "focusAreas": [
+      "Full-Stack Development",
+      "SaaS Architecture",
+      "REST API Design",
+      "Multi-tenant Systems",
+      "Applied AI (RAG, OpenAI)",
+      "CI/CD & DevOps",
       "Technical Leadership",
-      "Stakeholder Communication",
-      "Requirements Analysis",
-      "Team Coordination",
-      "Incident Resolution",
-      "Iterative Delivery",
-      "User Support & Training",
-      "Technical Strategy"
+      "Code Quality & Testing"
     ]
   },
   "career": {}

--- a/apps/portfolio/tests/features/about/About.test.tsx
+++ b/apps/portfolio/tests/features/about/About.test.tsx
@@ -24,7 +24,7 @@ describe('About Section', () => {
 
     it('should render personal description', () => {
       renderAbout();
-      expect(screen.getByText(/tech lead con experiencia colaborando/i)).toBeInTheDocument();
+      expect(screen.getByText(/desarrollador full-stack con 6\+ años/i)).toBeInTheDocument();
     });
 
     it('should render GitHub stats block', () => {

--- a/apps/portfolio/tests/features/hero/Hero.test.tsx
+++ b/apps/portfolio/tests/features/hero/Hero.test.tsx
@@ -27,16 +27,14 @@ describe('Hero Section', () => {
       renderHero();
       expect(
         screen.getByRole('heading', {
-          name: /tech lead.*comunicación técnica.*saas.*node\.js.*react.*php\/symfony/i,
+          name: /full-stack developer/i,
         })
       ).toBeInTheDocument();
     });
 
     it('should render bio description', () => {
       renderHero();
-      expect(
-        screen.getByText(/tech lead especializado en traducir requisitos/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/desarrollador full-stack/i)).toBeInTheDocument();
     });
 
     it('should render all CTA buttons', () => {


### PR DESCRIPTION
Arregla dos cosas que dejó el PR #77:

1. **Bio del hero seguía mostrando copy viejo.** El Hero renderiza `tPersonal('bio.full')` → `messages.personal.bio`, que NO se actualizó en #77 (solo se cambió `personal.ts`, que alimenta el `<title>` SEO, no el render). Ahora `messages.personal.bio.short/full` y `focusAreas` (ES/EN) reflejan el perfil full-stack + IA.
2. **Tests en rojo** (CI de #77): 2 tests asertaban el tagline/about viejos, y el de bio asertaba el bio viejo. Actualizados los 3 a las nuevas cadenas:
   - Hero "render tagline" → /full-stack developer/i
   - Hero "render bio" → /desarrollador full-stack/i
   - About "render personal description" → /desarrollador full-stack con 6+ años/i

## Verificación
- `next build`: EXIT 0, 16/16. JSON válido, paridad ES↔EN. (Vitest se valida en CI — localmente no corre por node_modules de Windows.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)