### PR TITLE
content: añade proyecto DevFreelancer Tracker (CS50)

### DIFF
--- a/apps/portfolio/messages/en.json
+++ b/apps/portfolio/messages/en.json
@@ -528,6 +528,36 @@
   },
   "projects": {
     "details": {
+      "devfreelancer-client-tracker": {
+        "sections": [
+          {
+            "heading": "Context",
+            "body": "CS50x (Harvard) final project. A real web tool to manage recurring monthly maintenance for a freelance developer's clients, with three service plans (Basic, Business, Critical) and their associated checklists."
+          },
+          {
+            "heading": "Features",
+            "body": "Secure authentication (password hashing and sessions), client CRUD, automatic generation of monthly checklists per plan (5 to 14 tasks), task completion with real-time progress, and month-to-month navigation that preserves history."
+          },
+          {
+            "heading": "Architecture",
+            "body": "Flask (Python) backend with routes for authentication, clients and checklist. SQLite persistence with three tables (users, clients, checklist items) and indexes. Jinja2 templates (layout + five views) and a Bootstrap 5 + custom CSS interface."
+          },
+          {
+            "heading": "Stack and decisions",
+            "body": "Python/Flask + SQLite for simplicity and portability; plan and task logic lives in Python for flexibility; Bootstrap UI for a clean, responsive interface. ~657 lines of code."
+          },
+          {
+            "heading": "Takeaway",
+            "body": "Capstone after completing CS50x 2026 (C, Python, SQL, web development and Flask). Demonstrates full-stack development with Python, from the data model to the frontend, solving a real problem."
+          }
+        ],
+        "metrics": [
+          { "label": "Lines of code", "value": "~657" },
+          { "label": "Stack", "value": "Flask · SQLite" },
+          { "label": "Service plans", "value": "3" },
+          { "label": "Origin", "value": "CS50x final" }
+        ]
+      },
       "gestiono-mi-negocio-facturacion": {
         "sections": [
           {
@@ -649,6 +679,14 @@
       }
     ],
     "items": [
+      {
+        "id": "devfreelancer-client-tracker",
+        "title": "DevFreelancer Client Tracker — Freelance maintenance manager",
+        "description": "Web app (Flask + SQLite) that automates recurring monthly maintenance for freelance clients: secure auth, client CRUD, plan-based dynamic checklists (Basic/Business/Critical), month-to-month navigation and a progress dashboard. CS50x final project, in real use.",
+        "tech": ["Flask", "Python", "SQLite", "Jinja2", "Bootstrap 5", "HTML5", "CSS3"],
+        "links": { "github": "https://github.com/GMNAPI/devfreelancer-tracker" },
+        "categoryId": "herramientas"
+      },
       {
         "id": "gestiono-mi-negocio-facturacion",
         "title": "GestionoMiNegocio (GMN) — Electronic invoicing SaaS platform",

--- a/apps/portfolio/messages/es.json
+++ b/apps/portfolio/messages/es.json
@@ -528,6 +528,36 @@
   },
   "projects": {
     "details": {
+      "devfreelancer-client-tracker": {
+        "sections": [
+          {
+            "heading": "Contexto",
+            "body": "Proyecto final de CS50x (Harvard). Herramienta web real para gestionar el mantenimiento recurrente mensual de los clientes de un desarrollador freelance, con tres planes de servicio (Básico, Negocio, Crítico) y sus checklists asociados."
+          },
+          {
+            "heading": "Funcionalidad",
+            "body": "Autenticación segura (hash de contraseña y sesiones), CRUD de clientes, generación automática de checklists mensuales según el plan (de 5 a 14 tareas), marcado de tareas con progreso en tiempo real y navegación entre meses preservando el historial."
+          },
+          {
+            "heading": "Arquitectura",
+            "body": "Backend en Flask (Python) con rutas para autenticación, clientes y checklist. Persistencia en SQLite con tres tablas (usuarios, clientes, ítems de checklist) e índices. Plantillas Jinja2 (layout + cinco vistas) e interfaz con Bootstrap 5 y CSS propio."
+          },
+          {
+            "heading": "Stack y decisiones",
+            "body": "Python/Flask + SQLite por simplicidad y portabilidad; la lógica de planes y tareas vive en Python para flexibilidad; UI con Bootstrap para una interfaz limpia y responsive. ~657 líneas de código."
+          },
+          {
+            "heading": "Aprendizaje",
+            "body": "Capstone tras completar CS50x 2026 (C, Python, SQL, desarrollo web y Flask). Demuestra desarrollo full-stack con Python, del modelo de datos al frontend, resolviendo un problema real."
+          }
+        ],
+        "metrics": [
+          { "label": "Líneas de código", "value": "~657" },
+          { "label": "Stack", "value": "Flask · SQLite" },
+          { "label": "Planes de servicio", "value": "3" },
+          { "label": "Origen", "value": "CS50x final" }
+        ]
+      },
       "gestiono-mi-negocio-facturacion": {
         "sections": [
           {
@@ -649,6 +679,14 @@
       }
     ],
     "items": [
+      {
+        "id": "devfreelancer-client-tracker",
+        "title": "DevFreelancer Client Tracker — Gestión de mantenimiento freelance",
+        "description": "Aplicación web (Flask + SQLite) que automatiza el mantenimiento recurrente mensual de clientes freelance: autenticación segura, CRUD de clientes, checklists dinámicos por plan (Básico/Negocio/Crítico), navegación entre meses y dashboard de progreso. Proyecto final de CS50x, en uso real.",
+        "tech": ["Flask", "Python", "SQLite", "Jinja2", "Bootstrap 5", "HTML5", "CSS3"],
+        "links": { "github": "https://github.com/GMNAPI/devfreelancer-tracker" },
+        "categoryId": "herramientas"
+      },
       {
         "id": "gestiono-mi-negocio-facturacion",
         "title": "GestionoMiNegocio (GMN) — Plataforma SaaS de facturación electrónica",

--- a/apps/portfolio/src/shared/constants/project-slugs.ts
+++ b/apps/portfolio/src/shared/constants/project-slugs.ts
@@ -6,6 +6,7 @@
  */
 
 export const PROJECT_SLUGS = [
+  'devfreelancer-client-tracker',
   'gestiono-mi-negocio-facturacion',
   'vita-liber-erp-interno',
   'fastbyte-api-servicios',


### PR DESCRIPTION
Tarjeta + página de detalle (ES/EN) del proyecto final de CS50x, enlazado al repo público github.com/GMNAPI/devfreelancer-tracker. Build 16+ páginas OK.